### PR TITLE
Add refactoring docs

### DIFF
--- a/docs/api_modules.md
+++ b/docs/api_modules.md
@@ -1,0 +1,12 @@
+# API Isolation Candidates
+
+The legacy `app/` directory contains multiple CakePHP controllers and models. The following areas can be separated behind RESTful APIs or services:
+
+- **Event management** – `EventsController`, `Event` model, and related components handle creation, upload, and review of events.
+- **Criteria management** – `CriteriasController` and `Criteria` model maintain definitions for coded criteria.
+- **Solicitations** – `SolicitationsController` and `Solicitation` model send requests and track responses.
+- **User management** – `UsersController` and `User` model handle authentication and roles.
+- **Patient records** – `Patient` model contains patient information referenced by events.
+- **Review and derived data** – `Review` and `EventDerivedData` models store reviewer input and calculated fields.
+
+Isolating these domains behind APIs would allow them to be consumed by a modern PHP or JavaScript front end and enable gradual migration off the CakePHP stack.

--- a/docs/llm_assistance.md
+++ b/docs/llm_assistance.md
@@ -1,0 +1,11 @@
+# Using an LLM for Refactoring
+
+A language model can support refactoring by:
+
+1. **Generating Updated PHP** – Provide code samples that follow modern PHP standards (namespaces, PSR style, exceptions) when prompted with existing functions or controllers.
+2. **Suggesting Framework Migration** – Outline how legacy CakePHP code maps to structures in Laravel or Symfony. The model can propose class skeletons or routing definitions.
+3. **Automated Documentation** – Produce inline documentation and comments for legacy methods to clarify behavior before rewriting.
+4. **Unit Test Generation** – Draft PHPUnit test cases for controllers and models to validate behavior before and after changes.
+5. **Incremental Translation** – When rewriting modules to an API, the model can help translate business logic into controller methods for the new framework.
+
+Combining these capabilities with manual review allows gradual modernization while ensuring that existing features remain intact.

--- a/docs/refactoring_log.md
+++ b/docs/refactoring_log.md
@@ -1,0 +1,5 @@
+# Refactoring Log
+
+## 2023-11-24
+- Created documentation outlining modules that could be isolated behind APIs.
+- Added guidance on how an LLM can assist with modernizing the codebase.


### PR DESCRIPTION
## Summary
- document which CakePHP modules could be wrapped by APIs
- describe how an LLM could help migrate the PHP codebase
- start a refactoring log

## Testing
- `php -v` *(fails: command not found)*
- `bash -c 'php -q cake/console/cake.php'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686586b1e1a0832691ffa769d3de52fd