### PR TITLE
Add development docs and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+
+      - name: Build React app
+        if: ${{ hashFiles('frontend/package.json') != '' }}
+        run: |
+          cd frontend
+          npm ci
+          npm run build
+
+      - name: Run PHP tests
+        run: |
+          cd app
+          bash ../cake/console/cake testsuite app all

--- a/README.md
+++ b/README.md
@@ -207,3 +207,7 @@ $ ../cake/console/cake testsuite app all
         )
          at [/srv/www/cnics.cirg.washington.edu/htdocs/mci/app/tests/cases/models/my_test_case.php line 56]
         2/2 test cases complete: 4 passes, 1 fails.
+
+## Local Development
+
+See [docs/development.md](docs/development.md) for instructions on running the application with Docker.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,46 @@
+# Development Setup
+
+This project uses `docker-compose` to run the PHP backend, React frontend and Keycloak for authentication.
+
+## Prerequisites
+
+* [Docker](https://docs.docker.com/get-docker/) and [docker-compose](https://docs.docker.com/compose/install/) installed
+* This repository cloned locally
+
+## Running the stack
+
+1. Build the containers and install dependencies:
+   ```bash
+   docker-compose build
+   ```
+2. Start all services in the background:
+   ```bash
+   docker-compose up -d
+   ```
+3. The React application will be served on <http://localhost:3000> and the PHP backend on <http://localhost:8080>.
+4. Keycloak will be available on <http://localhost:8081/auth>.
+
+## Building the React application
+
+If you want to run the build manually (for example in CI):
+```bash
+docker-compose run --rm frontend npm run build
+```
+This will create production assets inside the `frontend/build` directory.
+
+## Running the PHP backend
+
+To start just the PHP service without the other containers:
+```bash
+docker-compose run --rm php
+```
+You can then reach the application at <http://localhost:8080> after the container starts.
+
+## Accessing Keycloak
+
+Keycloak is bundled as a service in `docker-compose.yml`. To open the admin console, visit:
+```
+http://localhost:8081/auth
+```
+Default credentials are set via environment variables in the compose file (e.g. `KEYCLOAK_USER`/`KEYCLOAK_PASSWORD`).
+


### PR DESCRIPTION
## Summary
- document local development using docker-compose
- link README to new docs
- add basic GitHub Actions workflow for PHP tests and React build

## Testing
- `bash ../cake/console/cake testsuite app all` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686586af4e248326b1cb1583a059018e