### PR TITLE
Add Docker container configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM php:5.6-apache
+
+# Install PHP extensions required for CakePHP
+RUN docker-php-ext-install pdo_mysql
+
+# Enable Apache modules
+RUN a2enmod rewrite
+
+# Copy application
+COPY . /var/www/html
+
+# Copy entrypoint
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+EXPOSE 80
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["apache2-foreground"]

--- a/README.md
+++ b/README.md
@@ -207,3 +207,26 @@ $ ../cake/console/cake testsuite app all
         )
          at [/srv/www/cnics.cirg.washington.edu/htdocs/mci/app/tests/cases/models/my_test_case.php line 56]
         2/2 test cases complete: 4 passes, 1 fails.
+
+## Container Setup
+
+This repository includes a lightweight Docker configuration based on the setup used in the `asbi-screening-app` project. A basic PHP/Apache image is provided along with a docker-compose file for local development.
+
+### Build and Run
+
+```bash
+# build the container
+docker-compose build
+
+# start the container on http://localhost:8080
+docker-compose up
+```
+
+### Environment Variables
+
+Runtime configuration is provided via `default.env` which is loaded by `docker-compose`. The following variables are available:
+
+- `FHIR_SERVER` – URL of the FHIR server used by the application.
+
+You may override these values by creating your own `.env` or editing `default.env`.
+

--- a/default.env
+++ b/default.env
@@ -1,0 +1,3 @@
+# Default environment variables for mci container
+# URL to FHIR server used by the application
+FHIR_SERVER=http://example-fhir-server.com

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,8 @@
+version: "3.7"
+services:
+  web:
+    build: .
+    ports:
+      - "8080:80"
+    env_file:
+      - default.env

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+# Write environment variables used by the app
+if [ -n "$FHIR_SERVER" ]; then
+  echo "{\"FHIR_SERVER\": \"$FHIR_SERVER\"}" > /var/www/html/env.json
+fi
+
+exec "$@"


### PR DESCRIPTION
## Summary
- add Dockerfile and docker entrypoint
- add docker-compose config and default environment variables
- document container usage in README

## Testing
- `docker-compose --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686586ac30c083268d4a884dead868be