### PR TITLE
Add log aggregation services

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,9 +7,14 @@ services:
       - .:/var/www/html:ro
     environment:
       LOG_SERVER_URL: http://postgrest-internal:3000/events
+      DB_HOST: mariadb
+      DB_USER: root
+      DB_PASSWORD: example
+      DB_NAME: mci
     logging:
       driver: "json-file"
     depends_on:
+      - mariadb
       - postgrest
 
   postgrest:
@@ -41,6 +46,18 @@ services:
       - postgres-data:/var/lib/postgresql/data
       - logs-data:/var/log/postgresql
       - ./logs/logserver/sql/init.sql:/docker-entrypoint-initdb.d/init.sql
+    networks:
+      - internal
+
+  mariadb:
+    image: mariadb:10.11
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: example
+      MYSQL_DATABASE: mci
+    volumes:
+      - mariadb-data:/var/lib/mysql
+      - logs-data:/var/log/mysql
     networks:
       - internal
 
@@ -81,6 +98,7 @@ services:
 volumes:
   postgres-data:
   logs-data:
+  mariadb-data:
 
 networks:
   internal:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,89 @@
+version: "3.8"
+
+services:
+  web:
+    image: php:8.1-apache
+    volumes:
+      - .:/var/www/html:ro
+    environment:
+      LOG_SERVER_URL: http://postgrest-internal:3000/events
+    logging:
+      driver: "json-file"
+    depends_on:
+      - postgrest
+
+  postgrest:
+    image: postgrest/postgrest
+    restart: unless-stopped
+    environment:
+      PGRST_DB_URI: postgres://app_user:secret@postgres:5432/app_db
+      PGRST_DB_SCHEMA: api
+      PGRST_DB_ANON_ROLE: web_anon
+      PGRST_JWT_SECRET: ${PGRST_JWT_SECRET}
+    depends_on:
+      - postgres
+    volumes:
+      - logs-data:/var/log/postgrest
+    networks:
+      internal:
+        aliases:
+          - postgrest-internal
+      ingress:
+
+  postgres:
+    image: postgres:${POSTGRES_IMAGE_TAG:-12}
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: app_db
+      POSTGRES_USER: app_user
+      POSTGRES_PASSWORD: secret
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+      - logs-data:/var/log/postgresql
+      - ./logs/logserver/sql/init.sql:/docker-entrypoint-initdb.d/init.sql
+    networks:
+      - internal
+
+  auth-proxy:
+    image: quay.io/oauth2-proxy/oauth2-proxy:v7.3.0
+    expose:
+      - 4180
+    environment:
+      OAUTH2_PROXY_CLIENT_ID: logs_oauth2_proxy
+      OAUTH2_PROXY_HTTP_ADDRESS: 0.0.0.0:4180
+      OAUTH2_PROXY_REVERSE_PROXY: "true"
+      OAUTH2_PROXY_UPSTREAMS: static://202
+      OAUTH2_PROXY_SET_XAUTHREQUEST: "true"
+      OAUTH2_PROXY_COOKIE_SECRET: ${OAUTH2_PROXY_COOKIE_SECRET}
+      OAUTH2_PROXY_COOKIE_DOMAINS: .${BASE_DOMAIN}
+      OAUTH2_PROXY_WHITELIST_DOMAINS: .${BASE_DOMAIN}
+      OAUTH2_PROXY_COOKIE_EXPIRE: 30m
+      OAUTH2_PROXY_COOKIE_REFRESH: 1m
+      OAUTH2_PROXY_EMAIL_DOMAINS: "*"
+      OAUTH2_PROXY_INSECURE_OIDC_ALLOW_UNVERIFIED_EMAIL: "true"
+      OAUTH2_PROXY_OIDC_ISSUER_URL: https://keycloak.${BASE_DOMAIN}/realms/ltt
+      OAUTH2_PROXY_USER_ID_CLAIM: preferred_username
+      OAUTH2_PROXY_PROVIDER: oidc
+      OAUTH2_PROXY_SCOPE: openid profile email
+      OAUTH2_PROXY_CLIENT_SECRET: ${OAUTH2_PROXY_CLIENT_SECRET}
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.auth-proxy.rule=Host(`auth-proxy.${BASE_DOMAIN}`)
+      - traefik.http.routers.auth-proxy.entrypoints=websecure
+      - traefik.http.routers.auth-proxy.tls.certresolver=letsencrypt
+      - traefik.http.middlewares.oidc-auth.forwardAuth.address=http://auth-proxy:4180/
+      - traefik.http.middlewares.oidc-auth.forwardAuth.trustForwardHeader=true
+      - traefik.http.middlewares.oidc-auth.forwardAuth.authResponseHeaders=X-Auth-Request-User,X-Auth-Request-Email,X-Auth-Request-Access-Token,Authorization
+    networks:
+      - internal
+      - ingress
+
+volumes:
+  postgres-data:
+  logs-data:
+
+networks:
+  internal:
+  ingress:
+    external: true
+

--- a/logs/README.md
+++ b/logs/README.md
@@ -1,0 +1,17 @@
+# Logserver
+
+Sets up a central location to store and view logs. Container logs are persisted
+to a named Docker volume so data is retained between runs.
+
+
+## Setup
+
+Copy the .env file default:
+
+    cp default.env .env
+
+Modify each newly copied env file as necessary. Lines that are not commented-out are required, commented lines are optional.
+
+### Sending logs
+
+Other services should send their log messages to the `LOG_SERVER_URL` environment variable. In the provided `docker-compose.yaml` the main `web` service forwards log events to `http://postgrest-internal:3000/events`.

--- a/logs/docker-compose.yaml
+++ b/logs/docker-compose.yaml
@@ -1,0 +1,94 @@
+---
+services:
+  postgrest:
+    extends:
+      file: ./logserver/docker-compose.yaml
+      service: postgrest
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.logserver-auth-${COMPOSE_PROJECT_NAME}.rule=Method(`GET`) && Host(`logs.${BASE_DOMAIN}`)
+      - traefik.http.routers.logserver-auth-${COMPOSE_PROJECT_NAME}.entrypoints=websecure
+      - traefik.http.routers.logserver-auth-${COMPOSE_PROJECT_NAME}.middlewares=oidc-auth-${COMPOSE_PROJECT_NAME}
+      - traefik.http.routers.logserver-auth-${COMPOSE_PROJECT_NAME}.tls=true
+      - traefik.http.routers.logserver-auth-${COMPOSE_PROJECT_NAME}.tls.certresolver=letsencrypt
+
+      # POST requests to /events are authenticated by postgrest JWT
+      - traefik.http.routers.logserver-unauth-${COMPOSE_PROJECT_NAME}.rule=Method(`POST`) && Host(`logs.${BASE_DOMAIN}`)
+      - traefik.http.routers.logserver-unauth-${COMPOSE_PROJECT_NAME}.entrypoints=websecure
+      - traefik.http.routers.logserver-unauth-${COMPOSE_PROJECT_NAME}.tls=true
+      - traefik.http.routers.logserver-unauth-${COMPOSE_PROJECT_NAME}.tls.certresolver=letsencrypt
+    networks:
+      internal:
+        aliases:
+          - postgrest-internal-${COMPOSE_PROJECT_NAME}
+      ingress:
+
+  postgres:
+    extends:
+      file: ./logserver/docker-compose.yaml
+      service: postgres
+    networks:
+      - internal
+
+  auth-proxy:
+    image: quay.io/oauth2-proxy/oauth2-proxy:v7.3.0
+    # oauth2-proxy does not EXPOSE (advertise) the ports it listens on in its docker image
+    expose:
+      - 4180
+    environment:
+      OAUTH2_PROXY_CLIENT_ID: logs_oauth2_proxy
+      OAUTH2_PROXY_HTTP_ADDRESS: 0.0.0.0:4180
+      OAUTH2_PROXY_REVERSE_PROXY: "true"
+
+      # when authenticated, return a static 202 response
+      # https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview/#forwardauth-with-static-upstreams-configuration
+      OAUTH2_PROXY_UPSTREAMS: static://202
+
+      # needed to set X-Auth-Request-Email
+      OAUTH2_PROXY_SET_XAUTHREQUEST: "true"
+
+      # general cookie settings
+      OAUTH2_PROXY_COOKIE_SECRET: ${OAUTH2_PROXY_COOKIE_SECRET}
+      OAUTH2_PROXY_COOKIE_DOMAINS: .${BASE_DOMAIN}
+      OAUTH2_PROXY_WHITELIST_DOMAINS: .${BASE_DOMAIN}
+      OAUTH2_PROXY_COOKIE_EXPIRE: 30m
+      OAUTH2_PROXY_COOKIE_REFRESH: 1m
+      OAUTH2_PROXY_EMAIL_DOMAINS: "*"
+      OAUTH2_PROXY_INSECURE_OIDC_ALLOW_UNVERIFIED_EMAIL: "true"
+      OAUTH2_PROXY_OIDC_ISSUER_URL: https://keycloak.${BASE_DOMAIN}/realms/ltt
+      OAUTH2_PROXY_USER_ID_CLAIM: preferred_username
+
+      # OIDC integration settings
+      OAUTH2_PROXY_PROVIDER: oidc
+      OAUTH2_PROXY_SCOPE: openid profile email
+      OAUTH2_PROXY_CLIENT_SECRET: ${OAUTH2_PROXY_CLIENT_SECRET}
+
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.auth-proxy-${COMPOSE_PROJECT_NAME}.rule=Host(`auth-proxy.${BASE_DOMAIN}`) || (PathPrefix(`/oauth2`) && (Host(`${BASE_DOMAIN}`) || HostRegexp(`{subdomain:.+}.${BASE_DOMAIN}`)))
+
+      - traefik.http.routers.auth-proxy-${COMPOSE_PROJECT_NAME}.entrypoints=websecure
+      - traefik.http.routers.auth-proxy-${COMPOSE_PROJECT_NAME}.tls.certresolver=letsencrypt
+
+      # https://oauth2-proxy.github.io/oauth2-proxy/configuration/integration/#forwardauth-with-static-upstreams-configuration
+      - traefik.http.middlewares.oidc-auth-${COMPOSE_PROJECT_NAME}.forwardAuth.address=http://auth-proxy-${COMPOSE_PROJECT_NAME}:4180/
+      - traefik.http.middlewares.oidc-auth-${COMPOSE_PROJECT_NAME}.forwardAuth.trustForwardHeader=true
+      - traefik.http.middlewares.oidc-auth-${COMPOSE_PROJECT_NAME}.forwardAuth.authResponseHeaders=X-Auth-Request-User,X-Auth-Request-Email,X-Auth-Request-Access-Token,Authorization
+    networks:
+      ingress:
+        aliases:
+          - auth-proxy-${COMPOSE_PROJECT_NAME}
+      internal:
+
+volumes:
+  postgres-data: {}
+  logs-data: {}
+
+networks:
+  # internal network for backing services
+  internal:
+
+  # ingress network
+  ingress:
+    external: true
+    name: external_web

--- a/logs/logserver/docker-compose.yaml
+++ b/logs/logserver/docker-compose.yaml
@@ -1,0 +1,32 @@
+version: "3.1"
+
+services:
+  # https://github.com/suzel/docker-postgrest
+  postgrest:
+    image: postgrest/postgrest
+    restart: unless-stopped
+    environment:
+      PGRST_DB_URI: postgres://app_user:secret@postgres:5432/app_db
+      PGRST_DB_SCHEMA: api
+      PGRST_DB_ANON_ROLE: web_anon
+      PGRST_JWT_SECRET: ${PGRST_JWT_SECRET}
+    depends_on:
+      - postgres
+    volumes:
+      - logs-data:/var/log/postgrest
+
+  postgres:
+    image: postgres:${POSTGRES_IMAGE_TAG:-12}
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: app_db
+      POSTGRES_USER: app_user
+      POSTGRES_PASSWORD: secret
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+      - logs-data:/var/log/postgresql
+      - ./sql/init.sql:/docker-entrypoint-initdb.d/init.sql
+
+volumes:
+  postgres-data: {}
+  logs-data: {}

--- a/logs/logserver/sql/init.sql
+++ b/logs/logserver/sql/init.sql
@@ -1,0 +1,20 @@
+-- create schema used for API
+create schema api;
+
+-- create table used for log events
+create table api.events (
+	id serial primary key,
+	event jsonb not null
+);
+
+-- create web user w/ read only auth
+create role web_anon nologin;
+grant usage on schema api to web_anon;
+grant select on api.events to web_anon;
+
+-- create privileged user to write events
+create role event_logger nologin;
+grant usage on schema api to event_logger;
+grant all on api.events to event_logger;
+grant usage, select on sequence api.events_id_seq to event_logger;
+


### PR DESCRIPTION
## Summary
- add docker-compose with logserver services and example web app
- mount logs-data volume for persistent log storage
- document new log service setup

## Testing
- `docker-compose -f docker-compose.yaml config`

------
https://chatgpt.com/codex/tasks/task_e_686586a2aa1c8326b8492a000302fb31