### PR TITLE
Add dev compose for frontend

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,13 @@
+version: "3.8"
+services:
+  web:
+    image: node:20-alpine
+    working_dir: /app
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules
+    command: sh -c "npm install && npm run dev -- --host 0.0.0.0 --port 5173"
+    environment:
+      - VITE_API_URL=${VITE_API_URL:-http://localhost}
+    ports:
+      - "3000:5173"

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -31,6 +31,17 @@ and serves the production build on port `3000`.
 docker-compose up web
 ```
 
+For local development you can use the provided `docker-compose.override.yml`
+which mounts the source and runs the Vite dev server. This lets you edit files
+and immediately see changes without rebuilding the image:
+
+```bash
+docker-compose up web
+```
+
+When the override file is present the frontend will be available at
+<http://localhost:3000/>.
+
 You can override the `VITE_API_URL` environment variable in the compose file to
 point the frontend to a different backend API.
 


### PR DESCRIPTION
## Summary
- add docker-compose.override.yml so `docker-compose up web` runs the Vite dev server
- document using the override file in `frontend/README.md`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686d253799948326b218143fd0627613