### PR TITLE
Add backend skeleton and tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,3 +251,7 @@ You may override these values by creating your own `.env` or editing `default.en
 See [docs/development.md](docs/development.md) for instructions on running the application with Docker.
 
 
+
+## Backend Table Service
+
+A placeholder backend service under `backend/` will expose table data to the React frontend. See [docs/backend_table_service_tasks.md](docs/backend_table_service_tasks.md) for the planned tasks.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,3 @@
+# Backend Service
+
+This directory contains the source for an Express-based API that will serve table data to the React frontend. Implementation is pending.

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "backend",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node src/index.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2"
+  }
+}

--- a/backend/routes/tables.js
+++ b/backend/routes/tables.js
@@ -1,0 +1,1 @@
+// TODO: Define endpoints that respond to table queries.

--- a/backend/services/tableService.js
+++ b/backend/services/tableService.js
@@ -1,0 +1,1 @@
+// TODO: Implement database queries for fetching table data.

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1,0 +1,2 @@
+// Placeholder entry point for the backend API.
+// Routes and database connections will be added here.

--- a/docs/backend_table_service_tasks.md
+++ b/docs/backend_table_service_tasks.md
@@ -1,0 +1,13 @@
+# Backend Table Service Tasks
+
+This document outlines tasks for building the backend API that will deliver table data to the React frontend.
+
+- [ ] Set up basic Express server in `backend/src/index.js`.
+- [ ] Configure database connection using existing credentials.
+- [ ] Implement `/api/tables/:name` route in `backend/routes/tables.js` to return data for a given table query.
+- [ ] Wire up `tableService` with SQL queries pulled from the legacy PHP code.
+- [ ] Integrate authentication middleware to reuse the Keycloak setup.
+- [ ] Add unit tests for service functions and routes.
+- [ ] Document API endpoints and expected payloads.
+
+Each task can be completed independently. Focus first on reading from the legacy schema and returning JSON to the new React components.


### PR DESCRIPTION
## Summary
- add an empty `backend/` directory with an Express skeleton
- document tasks for building the backend API
- mention the backend service in the root README

## Testing
- `npm install` in `frontend`
- `npm run lint` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_686d35a89e608326a4a67a52dd44cc46