### PR TITLE
Add home screen instructions and table preview

### DIFF
--- a/frontend/src/pages/Home.css
+++ b/frontend/src/pages/Home.css
@@ -1,0 +1,26 @@
+.infobox {
+  background-color: #f2e8c2;
+  border: #f1d676 1px solid;
+  padding: 5px 10px;
+  border-radius: 12px;
+  margin-bottom: 1em;
+}
+
+.quick-search {
+  border: #a4a4a4 solid 2px;
+  border-radius: 4px;
+  padding: 2px 3px;
+  margin-bottom: 1em;
+}
+
+.data-table {
+  border-collapse: collapse;
+  width: 100%;
+  margin-bottom: 1em;
+}
+
+.data-table th,
+.data-table td {
+  border: 1px solid #ccc;
+  padding: 4px 8px;
+}

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,10 +1,108 @@
 import { Link } from 'react-router-dom'
+import { useEffect, useState } from 'react'
+import './Home.css'
+
+function Table({ rows }) {
+  if (!rows.length) return <p>No data found.</p>
+  const headers = Object.keys(rows[0])
+  return (
+    <table className="data-table">
+      <thead>
+        <tr>
+          {headers.map(h => (
+            <th key={h}>{h}</th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row, idx) => (
+          <tr key={idx}>
+            {headers.map(h => (
+              <td key={h}>{row[h]}</td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}
 
 function Home() {
+  const [rows, setRows] = useState([])
+  const [search, setSearch] = useState('')
+
+  useEffect(() => {
+    fetch('/api/tables/events')
+      .then((res) => res.json())
+      .then((json) => setRows(json.data || []))
+      .catch(() => {})
+  }, [])
+
+  const filteredRows = rows.filter((row) =>
+    Object.values(row).some((v) =>
+      String(v).toLowerCase().includes(search.toLowerCase())
+    )
+  )
+
   return (
     <div>
       <h1>CNICS Validation</h1>
       <p>Welcome to the CNICS Validation application.</p>
+
+      <div className="infobox">
+        <h3>Review packets should contain:</h3>
+        <ol>
+          <li>Physician's notes closest to potential Event date</li>
+          <li>Outpatient cardiology consultations</li>
+          <li>In-patient cardiology notes or consults</li>
+          <li>Baseline ECG</li>
+          <li>First 2 ECGs after admission or in-hospital event</li>
+          <li>Related procedure and diagnostic test results</li>
+          <li>Related laboratory evidence</li>
+          <li>
+            Please redact the personal identifiers including name, birthday, and
+            hospital number
+          </li>
+        </ol>
+        <div>
+          Full instructions:{' '}
+          <a href="/files/CNICS MI Review packet assembly instructions.doc">.doc</a>{' '}
+          |{' '}
+          <a
+            href="/files/CNICS MI Review packet assembly instructions.pdf"
+            target="_blank"
+          >
+            .pdf
+          </a>
+        </div>
+      </div>
+
+      <div className="infobox">
+        <h3>Review Instructions:</h3>
+        <div>
+          View as:{' '}
+          <a href="/files/CNICS MI reviewer instructions.doc">.doc</a> |{' '}
+          <a href="/files/CNICS MI reviewer instructions.pdf" target="_blank">
+            .pdf
+          </a>
+        </div>
+      </div>
+
+      <section>
+        <h3>Quick Search</h3>
+        <input
+          className="quick-search"
+          type="text"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search"
+        />
+      </section>
+
+      <section>
+        <h3>Table Preview</h3>
+        <Table rows={filteredRows} />
+      </section>
 
       <section>
         <h2>Administrative Tools</h2>


### PR DESCRIPTION
## Summary
- show review packet instructions and doc/pdf links on home screen
- show reviewer instructions
- add quick search box and table preview using new API
- style new elements

## Testing
- `npm --prefix backend test`
- `pytest flask_backend/tests`


------
https://chatgpt.com/codex/tasks/task_e_686e79fa7e508326b8a5985c9e0138ed