### PR TITLE
Update Flask backend with pooling and optional auth

### DIFF
--- a/flask_backend/README.md
+++ b/flask_backend/README.md
@@ -17,3 +17,7 @@ python -m flask_backend.app
 ```
 
 The API exposes `/api/tables/<name>` which returns up to 100 rows from the specified table.
+
+If the environment variable `KEYCLOAK_REALM` is set, requests are validated
+against a Keycloak server. Configure `KEYCLOAK_URL`, `KEYCLOAK_CLIENT_ID` and
+`KEYCLOAK_CLIENT_SECRET` accordingly.

--- a/flask_backend/app.py
+++ b/flask_backend/app.py
@@ -1,13 +1,44 @@
-from flask import Flask, jsonify
+from flask import Flask, jsonify, request, abort
 import os
 from dotenv import load_dotenv
+from keycloak import KeycloakOpenID
 from . import table_service
 
 load_dotenv()
 
 app = Flask(__name__)
 
+# Optional Keycloak configuration mirroring the Express backend
+keycloak_openid = None
+if os.getenv("KEYCLOAK_REALM"):
+    keycloak_openid = KeycloakOpenID(
+        server_url=os.getenv("KEYCLOAK_URL", "http://localhost:8080/"),
+        realm_name=os.getenv("KEYCLOAK_REALM"),
+        client_id=os.getenv("KEYCLOAK_CLIENT_ID"),
+        client_secret_key=os.getenv("KEYCLOAK_CLIENT_SECRET"),
+    )
+
+
+def requires_auth(func):
+    """Decorator that enforces Keycloak authentication if configured."""
+
+    def wrapper(*args, **kwargs):
+        if keycloak_openid:
+            auth = request.headers.get("Authorization", "")
+            if not auth.startswith("Bearer "):
+                abort(401)
+            token = auth.split(" ", 1)[1]
+            try:
+                keycloak_openid.userinfo(token)
+            except Exception:
+                abort(401)
+        return func(*args, **kwargs)
+
+    wrapper.__name__ = func.__name__
+    return wrapper
+
 @app.route('/api/tables/<name>')
+@requires_auth
 def get_table(name):
     try:
         rows = table_service.get_table_data(name)

--- a/flask_backend/requirements.txt
+++ b/flask_backend/requirements.txt
@@ -1,3 +1,4 @@
 flask
 python-dotenv
 mysql-connector-python
+python-keycloak

--- a/flask_backend/table_service.py
+++ b/flask_backend/table_service.py
@@ -1,5 +1,6 @@
 import os
 import mysql.connector
+from mysql.connector.pooling import MySQLConnectionPool
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -11,9 +12,23 @@ DB_CONFIG = {
     'database': os.getenv('DB_NAME', 'mci'),
 }
 
+# Lazily initialized connection pool similar to the Node backend implementation
+POOL = None
+
+
+def get_pool():
+    global POOL
+    if POOL is None:
+        POOL = MySQLConnectionPool(
+            pool_name="mci_pool",
+            pool_size=10,
+            **DB_CONFIG,
+        )
+    return POOL
+
 def get_table_data(name: str):
     """Return up to 100 rows from the specified table."""
-    conn = mysql.connector.connect(**DB_CONFIG)
+    conn = get_pool().get_connection()
     cursor = conn.cursor(dictionary=True)
     cursor.execute(f"SELECT * FROM `{name}` LIMIT 100")
     rows = cursor.fetchall()

--- a/flask_backend/tests/test_app.py
+++ b/flask_backend/tests/test_app.py
@@ -8,3 +8,14 @@ def test_get_table_route(mock_service):
     res = client.get('/api/tables/events')
     assert res.status_code == 200
     assert res.get_json() == {'data': [{'id': 1}]}
+
+
+@patch("flask_backend.table_service.get_table_data")
+def test_auth_required(mock_service):
+    mock_service.return_value = []
+    import importlib
+    app_mod = importlib.import_module('flask_backend.app')
+    app_mod.keycloak_openid = object()
+    client = app_mod.app.test_client()
+    res = client.get('/api/tables/events')
+    assert res.status_code == 401

--- a/flask_backend/tests/test_table_service.py
+++ b/flask_backend/tests/test_table_service.py
@@ -1,16 +1,17 @@
 from unittest.mock import MagicMock, patch
 import flask_backend.table_service as ts
 
-@patch('mysql.connector.connect')
-def test_get_table_data(mock_connect):
+
+@patch('flask_backend.table_service.get_pool')
+def test_get_table_data(mock_get_pool):
     mock_conn = MagicMock()
     mock_cursor = MagicMock()
     mock_cursor.fetchall.return_value = [{'id': 1}]
     mock_conn.cursor.return_value = mock_cursor
-    mock_connect.return_value = mock_conn
+    mock_get_pool.return_value.get_connection.return_value = mock_conn
 
     rows = ts.get_table_data('events')
 
-    mock_connect.assert_called()
+    mock_get_pool.assert_called()
     mock_cursor.execute.assert_called_with('SELECT * FROM `events` LIMIT 100')
     assert rows == [{'id': 1}]


### PR DESCRIPTION
## Summary
- add `python-keycloak` dependency
- support optional Keycloak auth in the Flask backend
- use a MySQL connection pool
- document authentication option
- update tests

## Testing
- `pytest flask_backend/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_686e86931d648326b3401980e5133695