### PR TITLE
Fix doc file links and add PDF generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,15 @@ You may override these values by creating your own `.env` or editing `default.en
 
 See [docs/development.md](docs/development.md) for instructions on running the application with Docker.
 
+## Generating PDF copies of instruction files
+
+Some pages link to `.pdf` versions of the documents under `app/webroot/files/`.
+These PDFs are not stored in the repository. Run `python generate_pdfs.py` from
+the project root to create them locally. The script converts modern `.docx`
+files to PDF and generates placeholder PDFs for older `.doc` files.
+The script requires the `python-docx` and `reportlab` packages which can be
+installed with `pip install python-docx reportlab`.
+
 
 
 ## Backend Table Service

--- a/app/views/elements/eventList.ctp
+++ b/app/views/elements/eventList.ctp
@@ -15,7 +15,7 @@ if ($showPatientInfo) {
     </ol>
     <div>Full instructions: 
     <?php
-    echo $html->link('.doc', '/files/' . $prefix . ' MI' . Event::UPLOAD_INSTRUCTIONS);
+    echo $html->link('.doc', '/files/' . $prefix . ' MI' . Event::UPLOAD_INSTRUCTIONS, array('download'=>true));
     echo " | ";
     echo $html->link('.pdf', '/files/' . $prefix . ' MI' . Event::UPLOAD_INSTRUCTIONS_PDF, array('target'=>'_blank'));
     ?>
@@ -29,7 +29,7 @@ if ($showPatientInfo) {
     <br />
     <div>View as: 
     <?php
-    echo $html->link('.doc', '/files/' . $prefix . Event::REVIEW_INSTRUCTIONS);
+    echo $html->link('.doc', '/files/' . $prefix . Event::REVIEW_INSTRUCTIONS, array('download'=>true));
     echo " | ";
     echo $html->link('.pdf', '/files/' . $prefix . Event::REVIEW_INSTRUCTIONS_PDF, array('target'=>'_blank'));
     ?>

--- a/app/views/events/review.ctp
+++ b/app/views/events/review.ctp
@@ -123,7 +123,7 @@
     <br />
     <div>View as: 
     <?php
-    echo $html->link('.doc', '/files/' . $prefix . Event::REVIEW_INSTRUCTIONS);
+    echo $html->link('.doc', '/files/' . $prefix . Event::REVIEW_INSTRUCTIONS, array('download'=>true));
     echo " | ";
     echo $html->link('.pdf', '/files/' . $prefix . Event::REVIEW_INSTRUCTIONS_PDF, array('target'=>'_blank'));
     ?>

--- a/app/views/events/scrub.ctp
+++ b/app/views/events/scrub.ctp
@@ -7,7 +7,7 @@
     <br />
     <div>View as: 
     <?php
-    echo $html->link('.doc', '/files/' . Event::SCRUB_INSTRUCTIONS);
+    echo $html->link('.doc', '/files/' . Event::SCRUB_INSTRUCTIONS, array('download'=>true));
     echo " | ";
     echo $html->link('.pdf', '/files/' . Event::SCRUB_INSTRUCTIONS_PDF, array('target'=>'_blank'));
     ?>

--- a/app/views/events/upload.ctp
+++ b/app/views/events/upload.ctp
@@ -90,7 +90,7 @@
     $prefix2 = (strpos(Router::url('/', true), 'mci') != true) ?
         'VTE' : 'MI';
 
-    echo $html->link('.doc', '/files/' . $prefix . ' MI' .Event::UPLOAD_INSTRUCTIONS);
+    echo $html->link('.doc', '/files/' . $prefix . ' MI' .Event::UPLOAD_INSTRUCTIONS, array('download'=>true));
     echo " | ";
     echo $html->link('.pdf', '/files/' . $prefix . ' MI' .Event::UPLOAD_INSTRUCTIONS_PDF, array('target'=>'_blank'));
     ?>

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -66,7 +66,7 @@ function Home() {
         </ol>
         <div>
           Full instructions:{' '}
-          <a href="/files/CNICS MI Review packet assembly instructions.doc">.doc</a>{' '}
+          <a href="/files/CNICS MI Review packet assembly instructions.doc" download>.doc</a>{' '}
           |{' '}
           <a
             href="/files/CNICS MI Review packet assembly instructions.pdf"
@@ -81,7 +81,7 @@ function Home() {
         <h3>Review Instructions:</h3>
         <div>
           View as:{' '}
-          <a href="/files/CNICS MI reviewer instructions.doc">.doc</a> |{' '}
+          <a href="/files/CNICS MI reviewer instructions.doc" download>.doc</a> |{' '}
           <a href="/files/CNICS MI reviewer instructions.pdf" target="_blank">
             .pdf
           </a>

--- a/generate_pdfs.py
+++ b/generate_pdfs.py
@@ -1,0 +1,37 @@
+import os
+from docx import Document
+from reportlab.pdfgen import canvas
+from reportlab.lib.pagesizes import letter
+
+FILES_DIR = 'app/webroot/files'
+
+for fname in os.listdir(FILES_DIR):
+    if fname.lower().endswith('.doc'):
+        base = fname[:-4]
+        pdf_path = os.path.join(FILES_DIR, base + '.pdf')
+        if os.path.exists(pdf_path):
+            continue
+        doc_path = os.path.join(FILES_DIR, fname)
+        # try to read as docx
+        try:
+            doc = Document(doc_path)
+            text = '\n'.join(p.text for p in doc.paragraphs)
+            if not text.strip():
+                raise ValueError('empty')
+        except Exception:
+            # couldn't parse doc, just create stub
+            text = (
+                f'PDF version of {fname} is not available. ' \
+                f'Please open the .doc file instead.'
+            )
+        c = canvas.Canvas(pdf_path, pagesize=letter)
+        width, height = letter
+        y = height - 40
+        for line in text.split('\n'):
+            c.drawString(40, y, line)
+            y -= 15
+            if y < 40:
+                c.showPage()
+                y = height - 40
+        c.save()
+        print('created', pdf_path)


### PR DESCRIPTION
## Summary
- generate local PDFs from the instruction documents
- document how to generate PDFs in the README
- force `.doc` links to download instead of opening

## Testing
- `npm --prefix frontend run lint` *(fails: Cannot find package '@eslint/js')*
- `npm --prefix backend test` *(fails: jest not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_687130b646d4832689d482e50a917fb9